### PR TITLE
Corrected blacklist

### DIFF
--- a/blacklist
+++ b/blacklist
@@ -753,7 +753,6 @@ Albero
 Albersmeier
 Albersmeiers
 Alberta
-Alberten
 Alberts
 Albhard
 Albi
@@ -848,7 +847,6 @@ Allensbach
 Allensbachs
 Allenstein
 Allensteins
-Aller
 Allgäus
 Allstedt
 Allstedts
@@ -870,7 +868,6 @@ Alpharden
 Alphons
 Alpirsbach
 Alpirsbachs
-Als
 Alsenborn
 Alsenborns
 Alsenz
@@ -1035,7 +1032,6 @@ Andamanensee
 Anden
 Andernach
 Andernachs
-Anders
 Anderß
 Andi
 Andis
@@ -1555,7 +1551,6 @@ Barnim
 Barnims
 Barntrup
 Barntrups
-Barockes
 Barranke
 Barsinghausen
 Barsinghausens
@@ -1832,7 +1827,6 @@ Biermeiers
 Bihar
 Bilbao
 Bilbaos
-BILD
 Bilhildis
 Billiard
 Billiards
@@ -2150,7 +2144,6 @@ Bukkakes
 Bukowina
 Bulgarien
 Bulgariens
-BUND
 Bündes
 Burgbernheim
 Burgenlands
@@ -2489,7 +2482,6 @@ Däänmark
 Dabergotz
 dabey
 d’accord
-DACH
 Dachau
 Dachaus
 DACHs
@@ -2973,7 +2965,6 @@ Ehlert
 Ehlin
 Ehlins
 Ehrenfriedersdorf
-Ehrlich
 Eibelstadt
 Eibelstadts
 Eiblmeier
@@ -3026,7 +3017,6 @@ Eisleben
 Eislingen
 Eissen
 Eisses
-Eitel
 eitelem
 eitelen
 eiteler
@@ -3132,11 +3122,9 @@ Engelbert
 Engele
 Engelen
 Engelsburg
-Enger
 Engern
 England
 Engmann
-ENIGMA
 Ennepetal
 Ennigerloh
 Ennis
@@ -3501,8 +3489,6 @@ Floridsdorfs
 Floris
 Flörsheim
 Florstadt
-Floss
-FLOSS
 Flösser
 Flössern
 Flössers
@@ -3542,7 +3528,6 @@ formirte
 Formosa
 Forstner
 FOSS
-Fossile
 Fossilen
 Fotzenlecker
 Fotzenleckern
@@ -3591,7 +3576,6 @@ Frauke
 Fraunhofer
 Fraw
 Frawen
-Frei
 Freia
 Freias
 Freiburg
@@ -4148,8 +4132,6 @@ Gothas
 Gothild
 Gothilden
 Gothilds
-GOtt
-GOttes
 Gottfried
 Gottfriede
 Gottfrieden
@@ -4266,7 +4248,6 @@ Grilletten
 Grimbart
 Grimma
 Grimmas
-Grins
 Grislibär
 Grislibären
 Gröbzig
@@ -4570,7 +4551,6 @@ Häßler
 häßlich
 häßliche
 Haßliebe
-Hatten
 Hattersheim
 Hattersheims
 Hattingen
@@ -4861,7 +4841,6 @@ Himalayas
 Himmler
 Hindukusch
 Hindukuschs
-Hingaben
 Hinkelshaut
 Hinrich
 Hintertupfingen
@@ -4883,7 +4862,6 @@ HNO
 HOAI
 HOAIs
 Hochheim
-Höchst
 Höchstadt
 Hockenheim
 Hoechst
@@ -5187,7 +5165,6 @@ Isolde
 Isolden
 Israel
 Israels
-ISS
 Issel
 Isselburg
 Isselburgs
@@ -5278,7 +5255,6 @@ Jaroslawl
 Jaroslawls
 Jars
 Jasnitz
-Jauch
 Jauchs
 Jaunde
 Jaundes
@@ -5421,7 +5397,6 @@ Jürgen
 Jürgens
 Juri
 Jurij
-Just
 Justin
 Justs
 Justus
@@ -5499,7 +5474,6 @@ kalvinistischster
 kalvinistischstes
 Kama
 Kambodschas
-Kamen
 Kamerun
 Kameruns
 Kampala
@@ -5871,7 +5845,6 @@ Krakaus
 Krasnojarsk
 Krasnojarsks
 kraß
-Krassen
 Kraus
 Krautheim
 Krautheims
@@ -6047,7 +6020,6 @@ Landstandes
 Landstands
 Langelsheim
 Langelsheims
-Langen
 Langenau
 Langenburg
 Langenfeld
@@ -6059,7 +6031,6 @@ Langenselbold
 Langenzenn
 Langeoog
 Langeoogs
-Langer
 Langewiesen
 Langhanke
 Langhankes
@@ -6566,8 +6537,6 @@ Malmö
 Mäls
 Malta
 Maltas
-Malte
-Malten
 Maltes
 Malukusee
 Malwaren
@@ -6575,12 +6544,10 @@ Malwida
 Malwine
 Malwinen
 Mamme
-MAN
 Managua
 Manama
 Manaslu
 Manaus
-Manche
 Manda
 Manderscheid
 Mandrenke
@@ -6704,7 +6671,6 @@ Maseru
 Maskat
 Maskats
 Massachusetts
-massen
 Massilia
 Masurens
 Masurka
@@ -7133,7 +7099,6 @@ Näfels
 NAFTA
 Nagold
 Nagolds
-Nahe
 Nahie
 Nahies
 Nahije
@@ -7250,7 +7215,6 @@ Nessessärs
 Nessie
 net
 Netanjahu
-Nette
 Nettetal
 Netzschkau
 Neuandalusien
@@ -7608,7 +7572,6 @@ Ohio
 Ohios
 Ohrdruf
 Ohrenberg
-OjE
 Okavango
 Okeanos
 Oki
@@ -7949,7 +7912,6 @@ plazierst
 plaziert
 plazierte
 pleitem
-pleiten
 pleiter
 pleites
 Plettenberg
@@ -8025,7 +7987,6 @@ Prometheus
 Promillen
 Prößdorf
 Prößdorfs
-Protokollieren
 Proveis
 Provence
 Prozeß
@@ -8197,7 +8158,6 @@ Rebekka
 Recife
 Recklinghausen
 Redlef
-Redlich
 Reebok
 Reeboks
 Reemt
@@ -8206,7 +8166,6 @@ Regatul
 Regensburg
 Regina
 Regnitz
-REH
 Rehau
 Rehhagel
 Rehna
@@ -8245,7 +8204,6 @@ Reschenpasses
 Reschs
 Resi
 Ressiewe
-REST
 Rethem
 Rethra
 Reutlingen
@@ -8491,9 +8449,7 @@ Rursee
 Rursees
 Rus
 Russ
-russe
 Rüsselsheim
-russen
 Russes
 russet
 russig
@@ -8623,7 +8579,6 @@ Sassenberg
 Sassnitz
 Saturns
 Satyren
-Sauer
 Sauerland
 Sauerlandes
 Sauerlands
@@ -8643,7 +8598,6 @@ Schaarschmidts
 Schadat
 Schaefer
 Schaffhausen
-Schales
 Schalkau
 Schamo
 Schanghai
@@ -8673,8 +8627,6 @@ schiesset
 schiesst
 Schifferstadt
 Schildau
-Schiller
-Schillern
 Schillers
 Schillingsfürst
 Schiltach
@@ -9093,7 +9045,6 @@ Ströbele
 Strunz
 Stuber
 Stübner
-Stumm
 Stuttgart
 StVO
 StVZO
@@ -9307,7 +9258,6 @@ Tays
 TCM
 Tecklenburg
 Tecklenburgs
-TEE
 Tegernsee
 Tegernsees
 Tegucigalpa
@@ -9950,7 +9900,6 @@ Vöhl
 Vöhrenbach
 Vöhringen
 Voigt
-Vokales
 Volck
 Völcker
 Volckes
@@ -10085,7 +10034,6 @@ Wehrden
 Weida
 Weidritz
 Weikersheim
-Weil
 Weilburg
 Weilerswist
 Weilheim
@@ -10218,7 +10166,6 @@ Wilfried
 Wilhelm
 Wilhelmine
 Wilhelmshaven
-Will
 Willaumez
 Willebadessen
 Willerscheid


### PR DESCRIPTION
These words exist in the German language. Only case sensitivity is sometimes different.
The game Lexica (see https://github.com/lexica/lexica) uses the delta between words and blacklist.
Therefore these words are incorrectly excluded.

Can this therefore please be merged to fix it. Thanks :-)